### PR TITLE
Serve site with Node/Express and EJS templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-Setup for DixonDoobies
+# Dixon Doobies Static Site
+
+This repository contains a small website for the Dixon Doobies brand. It uses Node.js with Express and EJS templates along with TailwindCSS via CDN and vanilla JavaScript.
+
+## Run locally
+
+```bash
+npm install
+npm start
+```
+
+Visit <http://localhost:3000> in your browser.
+
+## Deploy
+
+### Netlify
+1. Create a new site and link this repository.
+2. Use **npm start** as the build command. Netlify will run the Express server.
+
+### GitHub Pages
+GitHub Pages serves static files only. Render the EJS templates to HTML (for example: `npx ejs-cli views -o dist`) and deploy the generated output directory.
+
+## Future integrations
+- Point-of-sale and METRC-synced menu providers can be added for real-time inventory.
+- Geofencing and IP-based messages may be required for Colorado-only marketing.
+
+## Replacing placeholders
+- Replace `/public/assets/logo.svg` and remote hero images with branded assets.
+- Update the contact email and any social links in the footer.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dixon-doobies",
+  "version": "1.0.0",
+  "description": "Dixon Doobies static site served with Express",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ejs": "^3.1.9"
+  }
+}

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <text x="0" y="30" font-family="sans-serif" font-size="24">Dixon Doobies</text>
+  <text x="170" y="30" font-size="24">🍃</text>
+</svg>

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -1,0 +1,4 @@
+/* Minimal custom styles */
+.banner-space { padding-top: 3rem; }
+.toast { position: fixed; bottom: 1rem; right: 1rem; background: #064e3b; color: #f9fafb; padding: 0.5rem 1rem; border-radius: 0.25rem; }
+.hidden { display: none; }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,120 @@
+(() => {
+  function trapFocus(modal) {
+    const focusable = modal.querySelectorAll('button, [href], input');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    modal.addEventListener('keydown', e => {
+      if (e.key === 'Tab') {
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    });
+  }
+
+  function initAgeGate() {
+    const modal = document.getElementById('age-modal');
+    if (!modal) return;
+    const ok = localStorage.getItem('dd_age_ok');
+    const exp = parseInt(localStorage.getItem('dd_age_expires') || '0', 10);
+    const now = Date.now();
+    if (ok !== 'true' || now > exp) showModal();
+
+    function showModal() {
+      modal.classList.remove('hidden');
+      const yes = modal.querySelector('[data-age-yes]');
+      const no = modal.querySelector('[data-age-no]');
+      const msg = modal.querySelector('[data-age-message]');
+      trapFocus(modal);
+      yes.focus();
+      yes.addEventListener('click', () => {
+        const expire = now + 30 * 24 * 60 * 60 * 1000;
+        localStorage.setItem('dd_age_ok', 'true');
+        localStorage.setItem('dd_age_expires', expire);
+        modal.classList.add('hidden');
+      });
+      no.addEventListener('click', () => {
+        localStorage.setItem('dd_age_ok', 'false');
+        msg.classList.remove('hidden');
+      });
+    }
+  }
+
+  function initNav() {
+    const btn = document.getElementById('nav-toggle');
+    const menu = document.getElementById('nav-menu');
+    if (!btn || !menu) return;
+    btn.addEventListener('click', () => {
+      menu.classList.toggle('hidden');
+    });
+  }
+
+  function setActiveNav() {
+    const path = location.pathname.replace(/\/$/, '') || '/';
+    document.querySelectorAll('nav a').forEach(link => {
+      if (link.getAttribute('href') === path) {
+        link.classList.add('underline', 'text-green-700');
+      }
+    });
+  }
+
+  function initFAQ() {
+    document.querySelectorAll('[data-accordion]').forEach(item => {
+      const btn = item.querySelector('button');
+      const panel = item.querySelector('[data-accordion-panel]');
+      btn.addEventListener('click', () => {
+        const expanded = btn.getAttribute('aria-expanded') === 'true';
+        btn.setAttribute('aria-expanded', String(!expanded));
+        panel.classList.toggle('hidden', expanded);
+      });
+    });
+  }
+
+  function initComingSoon() {
+    document.querySelectorAll('[data-coming-soon]').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.preventDefault();
+        showToast('Available at launch.');
+      });
+    });
+  }
+
+  function showToast(msg) {
+    const t = document.createElement('div');
+    t.className = 'toast';
+    t.setAttribute('role', 'status');
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(() => t.remove(), 3000);
+  }
+
+  function initForms() {
+    const news = document.getElementById('newsletter-form');
+    if (news) {
+      news.addEventListener('submit', e => {
+        e.preventDefault();
+        news.querySelector('[data-success]').classList.remove('hidden');
+      });
+    }
+    const contact = document.getElementById('contact-form');
+    if (contact) {
+      contact.addEventListener('submit', e => {
+        e.preventDefault();
+        contact.querySelector('[data-success]').classList.remove('hidden');
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initAgeGate();
+    initNav();
+    setActiveNav();
+    initFAQ();
+    initComingSoon();
+    initForms();
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/', (req, res) => res.render('index'));
+app.get('/shop', (req, res) => res.render('shop'));
+app.get('/learn', (req, res) => res.render('learn'));
+app.get('/about', (req, res) => res.render('about'));
+
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -1,0 +1,32 @@
+<%- include('partials/head', { title: 'Dixon Doobies – About', description: 'About Dixon Doobies and how to contact us.' }) %>
+  <section>
+    <h1 class="text-3xl font-bold mb-4">About Dixon Doobies</h1>
+    <p>Dixon Doobies is a Colorado-born brand focused on premium products and education-first service.</p>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Contact Us</h2>
+    <form id="contact-form" action="#" class="space-y-4">
+      <label class="block">
+        <span class="sr-only">Name</span>
+        <input type="text" required class="w-full p-2 border" placeholder="Your name">
+      </label>
+      <label class="block">
+        <span class="sr-only">Email</span>
+        <input type="email" required class="w-full p-2 border" placeholder="you@example.com">
+      </label>
+      <label class="block">
+        <span class="sr-only">Message</span>
+        <textarea required class="w-full p-2 border" rows="4" placeholder="Message"></textarea>
+      </label>
+      <button type="submit" class="bg-green-700 text-white px-4 py-2 rounded hover:bg-green-800 motion-safe:transition-colors">Send</button>
+      <p data-success class="hidden text-green-700" role="status">Thanks—we’ll be in touch.</p>
+    </form>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Visit Us</h2>
+    <p>Location: TBD, Colorado</p>
+    <p>Hours: Mon–Sat 10am–8pm, Sun 11am–6pm</p>
+  </section>
+<%- include('partials/footer') %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,59 @@
+<%- include('partials/head', { title: 'Dixon Doobies – Premium Cannabis in Colorado', description: 'Premium, compliant cannabis education and future online ordering for Colorado adults.' }) %>
+  <section class="text-center py-16">
+    <div class="max-w-4xl mx-auto">
+      <img src="https://via.placeholder.com/1200x256.png?text=Hero+Image" alt="Cannabis product display placeholder" class="w-full h-64 object-cover mb-6">
+      <h1 class="text-3xl md:text-4xl font-bold mb-4">Elevate responsibly with Dixon Doobies</h1>
+      <p class="mb-6">Premium cannabis, Colorado compliant.</p>
+      <div class="space-x-4">
+        <a href="/shop" class="bg-green-700 text-white px-4 py-2 rounded hover:bg-green-800 motion-safe:transition-colors">View Shop</a>
+        <a href="/learn" class="bg-gray-200 text-gray-800 px-4 py-2 rounded hover:bg-gray-300 motion-safe:transition-colors">Learn the Basics</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 p-4">
+    <div class="bg-white p-6 rounded shadow">
+      <h2 class="text-xl font-semibold mb-2">Premium selection</h2>
+      <p>Curated flower, concentrates, and edibles sourced within Colorado.</p>
+    </div>
+    <div class="bg-white p-6 rounded shadow">
+      <h2 class="text-xl font-semibold mb-2">Knowledgeable guidance</h2>
+      <p>Our staff helps you choose products that fit your goals.</p>
+    </div>
+    <div class="bg-white p-6 rounded shadow">
+      <h2 class="text-xl font-semibold mb-2">Colorado-compliant purchasing</h2>
+      <p>Age verified experiences with local pickup or permitted delivery.</p>
+    </div>
+  </section>
+
+  <section class="bg-green-100 py-8">
+    <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-around text-center">
+      <div class="p-4">Browse</div>
+      <div class="p-4">→</div>
+      <div class="p-4">Age verify</div>
+      <div class="p-4">→</div>
+      <div class="p-4">Pickup/Delivery*</div>
+    </div>
+    <p class="text-center text-xs">*Delivery where permitted in Colorado.</p>
+  </section>
+
+  <section class="max-w-md mx-auto p-4 text-center">
+    <h2 class="text-2xl font-semibold mb-4">Newsletter</h2>
+    <form id="newsletter-form" action="#" class="space-y-4">
+      <label class="block">
+        <span class="sr-only">Email address</span>
+        <input type="email" required class="w-full p-2 border" placeholder="you@example.com">
+      </label>
+      <button type="submit" class="bg-green-700 text-white px-4 py-2 rounded hover:bg-green-800 motion-safe:transition-colors">Subscribe</button>
+      <p data-success class="hidden text-green-700" role="status">Thanks for subscribing!</p>
+    </form>
+  </section>
+
+  <section class="bg-gray-100 py-8">
+    <div class="max-w-4xl mx-auto text-center">
+      <h2 class="text-2xl font-semibold mb-4">Testimonials</h2>
+      <p class="italic mb-2">“Great service and friendly staff.”</p>
+      <p class="italic">“Quality products every time.”</p>
+    </div>
+  </section>
+<%- include('partials/footer') %>

--- a/views/learn.ejs
+++ b/views/learn.ejs
@@ -1,0 +1,39 @@
+<%- include('partials/head', { title: 'Dixon Doobies – Learn', description: 'Educational resources about cannabis for Colorado adults.' }) %>
+  <h1 class="text-3xl font-bold">Learn</h1>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Cannabis 101</h2>
+    <p>An introduction to the plant, cannabinoids like THC and CBD, and common forms such as flower, concentrates, and edibles.</p>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Onset & dosing basics</h2>
+    <p>Start low and go slow. Inhaled products act quickly, while edibles may take up to two hours to take effect.</p>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Safety & responsibility</h2>
+    <p>Do not drive under the influence. Keep cannabis secure and away from children and pets.</p>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Buying in Colorado</h2>
+    <p>You must be 21+ with a valid government ID. Local rules vary and shipping is not allowed.</p>
+  </section>
+
+  <section class="mt-8">
+    <h2 class="text-2xl font-semibold mb-4">FAQ</h2>
+    <div data-accordion class="border-b py-2">
+      <button class="w-full text-left flex justify-between" aria-expanded="false">What do I need to purchase?<span>+</span></button>
+      <div data-accordion-panel class="hidden mt-2">Bring a government-issued ID showing you are 21 or older.</div>
+    </div>
+    <div data-accordion class="border-b py-2">
+      <button class="w-full text-left flex justify-between" aria-expanded="false">How long do edibles take?<span>+</span></button>
+      <div data-accordion-panel class="hidden mt-2">Effects from edibles can take 30–120 minutes to appear.</div>
+    </div>
+    <div data-accordion class="border-b py-2">
+      <button class="w-full text-left flex justify-between" aria-expanded="false">Can I drive with cannabis?<span>+</span></button>
+      <div data-accordion-panel class="hidden mt-2">Driving under the influence is illegal. Store products securely during transport.</div>
+    </div>
+  </section>
+<%- include('partials/footer') %>

--- a/views/partials/banner.ejs
+++ b/views/partials/banner.ejs
@@ -1,0 +1,4 @@
+<div class="bg-green-900 text-white text-center text-xs p-2 fixed top-0 inset-x-0 z-50" role="note">
+  21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
+  <a href="/learn" class="underline">Learn more</a>
+</div>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,0 +1,30 @@
+  </main>
+
+  <footer class="bg-gray-800 text-gray-100 mt-12" role="contentinfo">
+    <div class="max-w-6xl mx-auto p-6 space-y-4">
+      <p>© <span id="year"></span> Dixon Doobies</p>
+      <p class="text-xs">Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will be fulfilled via in-store pickup or locally permitted delivery only. Content is for educational purposes only and not medical or legal advice.</p>
+      <div class="flex space-x-4" aria-label="Social links">
+        <span class="w-6 h-6 bg-gray-600 rounded-full" aria-hidden="true"></span>
+        <span class="w-6 h-6 bg-gray-600 rounded-full" aria-hidden="true"></span>
+        <span class="w-6 h-6 bg-gray-600 rounded-full" aria-hidden="true"></span>
+      </div>
+      <p><a href="mailto:info@example.com" class="underline">info@example.com</a></p>
+    </div>
+  </footer>
+
+  <div id="age-modal" class="fixed inset-0 bg-gray-900 bg-opacity-90 flex items-center justify-center hidden">
+    <div class="bg-white p-6 rounded max-w-sm text-center space-y-4" role="dialog" aria-modal="true" aria-labelledby="age-title">
+      <h2 id="age-title" class="text-xl font-bold">Are you 21 or older?</h2>
+      <div class="space-x-4">
+        <button data-age-yes class="px-4 py-2 bg-green-700 text-white rounded">Yes</button>
+        <button data-age-no class="px-4 py-2 bg-gray-700 text-white rounded">No</button>
+      </div>
+      <p data-age-message class="hidden text-red-600 text-sm">You must be 21+ to enter.</p>
+    </div>
+  </div>
+
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script src="/js/main.js" defer></script>
+</body>
+</html>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" class="banner-space">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= title %></title>
+  <meta name="description" content="<%= description %>">
+  <meta property="og:title" content="Dixon Doobies">
+  <meta property="og:description" content="Premium, compliant cannabis education and future online ordering for Colorado adults.">
+  <meta property="og:image" content="https://via.placeholder.com/1200x630.png?text=Dixon+Doobies">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14'%3E🌿%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css">
+  <link rel="stylesheet" href="/css/site.css">
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <%- include('banner') %>
+  <%- include('header') %>
+  <main id="main" tabindex="-1">

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,0 +1,20 @@
+<header class="bg-gray-50 shadow mt-10" role="banner">
+  <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
+    <a href="/" class="flex items-center space-x-2">
+      <img src="/assets/logo.svg" alt="Dixon Doobies" class="h-8">
+    </a>
+    <button id="nav-toggle" class="md:hidden p-2" aria-label="Toggle navigation">
+      <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
+      <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
+      <span class="block w-6 h-0.5 bg-gray-800"></span>
+    </button>
+    <nav>
+      <ul id="nav-menu" class="hidden md:flex space-x-4" aria-label="Primary">
+        <li><a href="/" class="hover:text-green-700 motion-safe:transition-colors">Home</a></li>
+        <li><a href="/shop" class="hover:text-green-700 motion-safe:transition-colors">Shop</a></li>
+        <li><a href="/learn" class="hover:text-green-700 motion-safe:transition-colors">Learn</a></li>
+        <li><a href="/about" class="hover:text-green-700 motion-safe:transition-colors">About</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1,0 +1,35 @@
+<%- include('partials/head', { title: 'Dixon Doobies – Shop (Coming Soon)', description: 'Future online ordering for Colorado adults when permitted.' }) %>
+  <h1 class="text-3xl font-bold mb-4">Shop (Coming Soon)</h1>
+  <p class="mb-8">When retail opens in your area, this page will support pay-ahead orders for in-store pickup and locally permitted delivery. We do not ship.</p>
+  <div class="grid gap-6 md:grid-cols-4">
+    <div class="bg-white p-4 rounded shadow text-center">
+      <img src="https://via.placeholder.com/400x200.png?text=Flower" alt="Flower placeholder" class="w-full h-32 object-cover mb-2">
+      <h2 class="font-semibold">Flower</h2>
+      <span class="inline-block bg-gray-300 text-gray-700 px-2 py-1 text-xs rounded mt-2">Coming Soon</span>
+      <button data-coming-soon aria-disabled="true" title="Available at launch." class="mt-4 w-full px-4 py-2 bg-green-700 text-white rounded opacity-50 cursor-not-allowed">Add to Cart</button>
+    </div>
+    <div class="bg-white p-4 rounded shadow text-center">
+      <img src="https://via.placeholder.com/400x200.png?text=Pre-rolls" alt="Pre-rolls placeholder" class="w-full h-32 object-cover mb-2">
+      <h2 class="font-semibold">Pre-Rolls</h2>
+      <span class="inline-block bg-gray-300 text-gray-700 px-2 py-1 text-xs rounded mt-2">Coming Soon</span>
+      <button data-coming-soon aria-disabled="true" title="Available at launch." class="mt-4 w-full px-4 py-2 bg-green-700 text-white rounded opacity-50 cursor-not-allowed">Add to Cart</button>
+    </div>
+    <div class="bg-white p-4 rounded shadow text-center">
+      <img src="https://via.placeholder.com/400x200.png?text=Vapes" alt="Vapes placeholder" class="w-full h-32 object-cover mb-2">
+      <h2 class="font-semibold">Vapes</h2>
+      <span class="inline-block bg-gray-300 text-gray-700 px-2 py-1 text-xs rounded mt-2">Coming Soon</span>
+      <button data-coming-soon aria-disabled="true" title="Available at launch." class="mt-4 w-full px-4 py-2 bg-green-700 text-white rounded opacity-50 cursor-not-allowed">Add to Cart</button>
+    </div>
+    <div class="bg-white p-4 rounded shadow text-center">
+      <img src="https://via.placeholder.com/400x200.png?text=Edibles" alt="Edibles placeholder" class="w-full h-32 object-cover mb-2">
+      <h2 class="font-semibold">Edibles</h2>
+      <span class="inline-block bg-gray-300 text-gray-700 px-2 py-1 text-xs rounded mt-2">Coming Soon</span>
+      <button data-coming-soon aria-disabled="true" title="Available at launch." class="mt-4 w-full px-4 py-2 bg-green-700 text-white rounded opacity-50 cursor-not-allowed">Add to Cart</button>
+    </div>
+  </div>
+
+  <section class="mt-12 space-y-4">
+    <h2 class="text-2xl font-semibold">Future integration</h2>
+    <p>Point-of-sale connections, METRC-synced menus, and geo-restricted checkout will ensure compliance with Colorado regulations.</p>
+  </section>
+<%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- reorganize static pages into EJS views with shared banner, header, and footer partials
- add Express server and move scripts, styles, and logo under `public`
- update navigation logic and README for Node-based workflow

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ejs)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd8c31fac8331b85b1b594a40ee7d