### PR TITLE
Replace Node app with static site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/404.html
+++ b/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page Not Found – Dixon Doobies</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-800 flex items-center justify-center min-h-screen">
+  <main class="text-center p-6">
+    <h1 class="text-2xl font-bold mb-4">Page not found</h1>
+    <p class="mb-4">The page you're looking for doesn't exist.</p>
+    <a href="index.html" class="text-green-700 underline">Return home</a>
+  </main>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Open `index.html` in any modern browser. No build step is required.
 
 ## Deploy
 ### Netlify
-Drag the project folder into the Netlify dashboard or connect the repository and set the site directory to the repository root.
+Netlify uses the included `netlify.toml` to publish the repository root with no build step.
+Drag the folder into the Netlify dashboard or connect the repo and deploy. Extensionless paths like `/shop` redirect to their corresponding HTML files.
 
 ### GitHub Pages
 Enable Pages in repository settings and choose the `main` branch with the root folder.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ Enable Pages in repository settings and choose the `main` branch with the root f
 - `assets/logo.svg` – swap with your brand logo.
 - Replace the hero placeholder block in `index.html` with a real image if desired.
 - Update `info@example.com` in footers and forms with a real contact email.
+
+## Compliance
+Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will
+be fulfilled via in-store pickup or locally permitted delivery only. All content
+is for educational purposes and not medical or legal advice.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-Setup for DixonDoobies
+# Dixon Doobies
+
+A small static website for the Dixon Doobies cannabis brand. Built with plain HTML, TailwindCSS via CDN, and vanilla JavaScript.
+
+## Structure
+- `index.html` – landing page
+- `shop.html` – sales placeholder
+- `learn.html` – cannabis education
+- `about.html` – contact and story
+- `assets/` – logo placeholder
+- `css/site.css` – minimal overrides
+- `js/main.js` – age gate, navigation, FAQ, and placeholder handlers
+
+## Local use
+Open `index.html` in any modern browser. No build step is required.
+
+## Deploy
+### Netlify
+Drag the project folder into the Netlify dashboard or connect the repository and set the site directory to the repository root.
+
+### GitHub Pages
+Enable Pages in repository settings and choose the `main` branch with the root folder.
+
+## Future integrations
+- Connect a point-of-sale or menu provider for live inventory (e.g., METRC-synced).
+- Add geofencing or messaging for Colorado-only marketing.
+
+## Replace placeholders
+- `assets/logo.svg` – swap with your brand logo.
+- Replace the hero placeholder block in `index.html` with a real image if desired.
+- Update `info@example.com` in footers and forms with a real contact email.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dixon Doobies – About</title>
+  <meta name="description" content="About Dixon Doobies and how to get in touch." />
+  <meta property="og:title" content="About Dixon Doobies" />
+  <meta property="og:description" content="Premium, local, education-first cannabis brand." />
+  <meta property="og:type" content="website" />
+  <link rel="icon" href="data:;base64,=" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/site.css" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div class="bg-green-900 text-gray-100 text-center text-sm p-2 sticky top-0 z-50">
+    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
+    <a href="learn.html" class="underline">Learn more</a>
+  </div>
+  <header class="bg-gray-900 text-gray-100">
+    <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
+      <a href="index.html" class="flex items-center gap-2">
+        <img src="assets/logo.svg" alt="" class="h-8 w-8" />
+        <span class="font-bold text-xl">Dixon Doobies</span>
+      </a>
+      <button id="menu-btn" class="md:hidden focus:outline-none" aria-label="Toggle navigation">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <nav id="nav" class="hidden md:flex gap-4">
+        <a href="index.html" class="hover:text-green-400">Home</a>
+        <a href="shop.html" class="hover:text-green-400">Shop</a>
+        <a href="learn.html" class="hover:text-green-400">Learn</a>
+        <a href="about.html" class="hover:text-green-400">About</a>
+      </nav>
+    </div>
+  </header>
+  <main class="min-h-screen p-6 max-w-3xl mx-auto space-y-8">
+    <section>
+      <h1 class="text-3xl font-bold mb-4">Our Story</h1>
+      <p>Dixon Doobies is a premium, local, education-first brand focused on responsible cannabis enjoyment in Colorado.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-2">Contact Us</h2>
+      <form action="#" data-message="contact-msg" class="space-y-2">
+        <label class="block"><span class="sr-only">Name</span><input type="text" required placeholder="Name" class="w-full p-2 border rounded" /></label>
+        <label class="block"><span class="sr-only">Email</span><input type="email" required placeholder="Email" class="w-full p-2 border rounded" /></label>
+        <label class="block"><span class="sr-only">Message</span><textarea required placeholder="Message" class="w-full p-2 border rounded"></textarea></label>
+        <button class="px-4 py-2 bg-green-800 text-white rounded">Send</button>
+      </form>
+      <p id="contact-msg" class="text-green-700 mt-2 hidden">Thanks—we’ll be in touch.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-2">Location &amp; Hours</h2>
+      <p>Location: TBD</p>
+      <p>Hours: TBD</p>
+    </section>
+  </main>
+  <footer class="bg-gray-900 text-gray-100 mt-8">
+    <div class="max-w-5xl mx-auto p-4 text-sm">
+      <p class="mb-2">© Dixon Doobies</p>
+      <p class="mb-2">Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will be fulfilled via in-store pickup or locally permitted delivery only. Content is for educational purposes only and not medical or legal advice.</p>
+      <p>Contact: <a href="mailto:info@example.com" class="underline">info@example.com</a></p>
+    </div>
+  </footer>
+  <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-gray-100 px-4 py-2 rounded hidden">Coming soon</div>
+  <div id="age-modal" class="fixed inset-0 bg-gray-900 bg-opacity-90 flex items-center justify-center hidden">
+    <div class="bg-white p-6 rounded max-w-sm mx-auto text-center">
+      <p class="mb-4 font-semibold">Are you 21 or older?</p>
+      <div class="flex justify-center gap-4">
+        <button id="age-yes" class="px-4 py-2 bg-green-800 text-white rounded">Yes</button>
+        <button id="age-no" class="px-4 py-2 bg-gray-300 rounded">No</button>
+      </div>
+      <p id="age-msg" class="mt-4 text-red-600 hidden">You must be 21+ to view this site.</p>
+    </div>
+  </div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="none">
+  <text x="40" y="28" font-size="24" font-family="sans-serif" fill="#064e3b">Dixon Doobies</text>
+  <path d="M20 10c-4 6-4 12 0 18 4-6 4-12 0-18z" fill="#064e3b"/>
+</svg>

--- a/css/site.css
+++ b/css/site.css
@@ -1,0 +1,5 @@
+html { scroll-behavior: smooth; }
+body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; }
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dixon Doobies – Home</title>
+  <meta name="description" content="Dixon Doobies offers cannabis education and Colorado-compliant purchasing." />
+  <meta property="og:title" content="Dixon Doobies" />
+  <meta property="og:description" content="Colorado cannabis education and future ordering." />
+  <meta property="og:type" content="website" />
+  <link rel="icon" href="data:;base64,=" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/site.css" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div class="bg-green-900 text-gray-100 text-center text-sm p-2 sticky top-0 z-50">
+    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
+    <a href="learn.html" class="underline">Learn more</a>
+  </div>
+  <header class="bg-gray-900 text-gray-100">
+    <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
+      <a href="index.html" class="flex items-center gap-2">
+        <img src="assets/logo.svg" alt="" class="h-8 w-8" />
+        <span class="font-bold text-xl">Dixon Doobies</span>
+      </a>
+      <button id="menu-btn" class="md:hidden focus:outline-none" aria-label="Toggle navigation">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <nav id="nav" class="hidden md:flex gap-4">
+        <a href="index.html" class="hover:text-green-400">Home</a>
+        <a href="shop.html" class="hover:text-green-400">Shop</a>
+        <a href="learn.html" class="hover:text-green-400">Learn</a>
+        <a href="about.html" class="hover:text-green-400">About</a>
+      </nav>
+    </div>
+  </header>
+  <main class="min-h-screen">
+    <section class="text-center bg-gray-200">
+      <div class="h-64 bg-gray-300 flex items-center justify-center">
+        <span class="sr-only">Placeholder hero image</span>
+      </div>
+    </section>
+    <section class="text-center py-12">
+      <h1 class="text-3xl md:text-5xl font-bold mb-4">Elevate responsibly.</h1>
+      <p class="mb-6 text-lg">Colorado-grown cannabis education and future ordering.</p>
+      <div class="flex justify-center gap-4">
+        <a href="shop.html" class="bg-green-800 text-white px-4 py-2 rounded">View Shop</a>
+        <a href="learn.html" class="bg-gray-800 text-white px-4 py-2 rounded">Learn the Basics</a>
+      </div>
+    </section>
+    <section class="max-w-5xl mx-auto p-6 grid gap-4 md:grid-cols-3">
+      <div class="p-4 bg-white shadow rounded">
+        <h3 class="font-semibold text-xl mb-2">Premium selection</h3>
+        <p>Curated Colorado flower and products.</p>
+      </div>
+      <div class="p-4 bg-white shadow rounded">
+        <h3 class="font-semibold text-xl mb-2">Knowledgeable guidance</h3>
+        <p>Friendly staff to help you choose.</p>
+      </div>
+      <div class="p-4 bg-white shadow rounded">
+        <h3 class="font-semibold text-xl mb-2">Colorado-compliant purchasing</h3>
+        <p>Pick up in store or permitted delivery.</p>
+      </div>
+    </section>
+    <section class="bg-gray-100 py-8">
+      <h2 class="text-2xl font-semibold text-center mb-4">How it works</h2>
+      <ol class="flex flex-col md:flex-row justify-center items-center gap-4 text-lg">
+        <li>Browse</li>
+        <li aria-hidden="true" class="text-2xl">→</li>
+        <li>Age verify</li>
+        <li aria-hidden="true" class="text-2xl">→</li>
+        <li>In-store pickup/permitted delivery</li>
+      </ol>
+    </section>
+    <section class="p-6 max-w-3xl mx-auto">
+      <h2 class="text-2xl font-semibold mb-4 text-center">Newsletter</h2>
+      <form action="#" data-message="newsletter-msg" class="flex flex-col md:flex-row gap-2">
+        <label for="news-email" class="sr-only">Email</label>
+        <input id="news-email" type="email" required class="flex-1 p-2 border rounded" placeholder="you@example.com" />
+        <button class="px-4 py-2 bg-green-800 text-white rounded">Subscribe</button>
+      </form>
+      <p id="newsletter-msg" class="text-green-700 mt-2 hidden">Thanks for subscribing!</p>
+    </section>
+    <section class="bg-gray-100 py-8">
+      <h2 class="text-2xl font-semibold text-center mb-4">Testimonials</h2>
+      <div class="max-w-3xl mx-auto space-y-4">
+        <blockquote class="p-4 bg-white shadow rounded">“Great service and knowledge.”</blockquote>
+        <blockquote class="p-4 bg-white shadow rounded">“Looking forward to their opening!”</blockquote>
+      </div>
+    </section>
+  </main>
+  <footer class="bg-gray-900 text-gray-100 mt-8">
+    <div class="max-w-5xl mx-auto p-4 text-sm">
+      <p class="mb-2">© Dixon Doobies</p>
+      <p class="mb-2">Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will be fulfilled via in-store pickup or locally permitted delivery only. Content is for educational purposes only and not medical or legal advice.</p>
+      <p>Contact: <a href="mailto:info@example.com" class="underline">info@example.com</a></p>
+    </div>
+  </footer>
+  <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-gray-100 px-4 py-2 rounded hidden">Coming soon</div>
+  <div id="age-modal" class="fixed inset-0 bg-gray-900 bg-opacity-90 flex items-center justify-center hidden">
+    <div class="bg-white p-6 rounded max-w-sm mx-auto text-center">
+      <p class="mb-4 font-semibold">Are you 21 or older?</p>
+      <div class="flex justify-center gap-4">
+        <button id="age-yes" class="px-4 py-2 bg-green-800 text-white rounded">Yes</button>
+        <button id="age-no" class="px-4 py-2 bg-gray-300 rounded">No</button>
+      </div>
+      <p id="age-msg" class="mt-4 text-red-600 hidden">You must be 21+ to view this site.</p>
+    </div>
+  </div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,97 @@
+function initNav() {
+  const menuBtn = document.getElementById('menu-btn');
+  const nav = document.getElementById('nav');
+  if (menuBtn && nav) {
+    menuBtn.addEventListener('click', () => nav.classList.toggle('hidden'));
+  }
+  const path = location.pathname.split('/').pop();
+  document.querySelectorAll('#nav a').forEach(a => {
+    const href = a.getAttribute('href');
+    if (href === path || (href === 'index.html' && path === '')) {
+      a.classList.add('font-semibold', 'text-green-700');
+      a.setAttribute('aria-current', 'page');
+    }
+  });
+}
+
+function initAgeGate() {
+  const modal = document.getElementById('age-modal');
+  if (!modal) return;
+  const key = 'dd_age_ok';
+  const tsKey = 'dd_age_ts';
+  const thirtyDays = 1000 * 60 * 60 * 24 * 30;
+  const ok = localStorage.getItem(key);
+  const ts = parseInt(localStorage.getItem(tsKey) || 0, 10);
+  if (ok === 'true' && Date.now() - ts < thirtyDays) return;
+  modal.classList.remove('hidden');
+  const yesBtn = modal.querySelector('#age-yes');
+  const noBtn = modal.querySelector('#age-no');
+  const msg = modal.querySelector('#age-msg');
+  const focusable = [yesBtn, noBtn];
+  function close() {
+    modal.classList.add('hidden');
+    localStorage.setItem(key, 'true');
+    localStorage.setItem(tsKey, Date.now().toString());
+  }
+  yesBtn.addEventListener('click', close);
+  noBtn.addEventListener('click', () => {
+    msg.classList.remove('hidden');
+    localStorage.setItem(key, 'false');
+  });
+  modal.addEventListener('keydown', e => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const current = focusable.indexOf(document.activeElement);
+      const next = e.shiftKey ? (current <= 0 ? focusable.length - 1 : current - 1) : (current === focusable.length - 1 ? 0 : current + 1);
+      focusable[next].focus();
+    }
+  });
+  yesBtn.focus();
+}
+
+function initFAQ() {
+  document.querySelectorAll('.faq-item button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', !expanded);
+      const panel = btn.nextElementSibling;
+      panel.classList.toggle('hidden');
+    });
+  });
+}
+
+function initComingSoon() {
+  const toast = document.getElementById('toast');
+  document.querySelectorAll('.coming-soon').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      if (!toast) {
+        alert('Available at launch.');
+        return;
+      }
+      toast.classList.remove('hidden');
+      setTimeout(() => toast.classList.add('hidden'), 2000);
+    });
+  });
+}
+
+function initForms() {
+  document.querySelectorAll('form[data-message]').forEach(form => {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const msg = document.getElementById(form.dataset.message);
+      if (msg) {
+        msg.classList.remove('hidden');
+        form.reset();
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initNav();
+  initAgeGate();
+  initFAQ();
+  initComingSoon();
+  initForms();
+});

--- a/learn.html
+++ b/learn.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dixon Doobies – Learn</title>
+  <meta name="description" content="Neutral cannabis education and safety information." />
+  <meta property="og:title" content="Learn about cannabis" />
+  <meta property="og:description" content="Cannabis basics, dosing, and safety." />
+  <meta property="og:type" content="website" />
+  <link rel="icon" href="data:;base64,=" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/site.css" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div class="bg-green-900 text-gray-100 text-center text-sm p-2 sticky top-0 z-50">
+    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
+    <a href="learn.html" class="underline">Learn more</a>
+  </div>
+  <header class="bg-gray-900 text-gray-100">
+    <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
+      <a href="index.html" class="flex items-center gap-2">
+        <img src="assets/logo.svg" alt="" class="h-8 w-8" />
+        <span class="font-bold text-xl">Dixon Doobies</span>
+      </a>
+      <button id="menu-btn" class="md:hidden focus:outline-none" aria-label="Toggle navigation">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <nav id="nav" class="hidden md:flex gap-4">
+        <a href="index.html" class="hover:text-green-400">Home</a>
+        <a href="shop.html" class="hover:text-green-400">Shop</a>
+        <a href="learn.html" class="hover:text-green-400">Learn</a>
+        <a href="about.html" class="hover:text-green-400">About</a>
+      </nav>
+    </div>
+  </header>
+  <main class="min-h-screen p-6 max-w-3xl mx-auto space-y-8">
+    <section>
+      <h1 class="text-3xl font-bold mb-4">Cannabis 101</h1>
+      <p>The cannabis plant contains compounds like THC and CBD. Products come in forms such as flower, concentrates, and edibles.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-2">Onset &amp; dosing basics</h2>
+      <p>Start low, go slow. Edibles may take up to two hours to feel effects, while inhalation is faster.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-2">Safety &amp; responsibility</h2>
+      <p>Do not drive under the influence. Keep cannabis away from children and pets and store securely.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-2">Buying in Colorado</h2>
+      <p>Adults 21+ with government ID can purchase. Local rules vary; no shipping allowed.</p>
+    </section>
+    <section>
+      <h2 class="text-2xl font-semibold mb-4">FAQ</h2>
+      <div class="space-y-2">
+        <div class="faq-item">
+          <button class="w-full text-left p-2 bg-gray-200" aria-expanded="false">How long do edibles take?</button>
+          <div class="hidden p-2 border">Edible onset can take 30–120 minutes.</div>
+        </div>
+        <div class="faq-item">
+          <button class="w-full text-left p-2 bg-gray-200" aria-expanded="false">Can I drive after using cannabis?</button>
+          <div class="hidden p-2 border">No. Driving under the influence is illegal and unsafe.</div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="bg-gray-900 text-gray-100 mt-8">
+    <div class="max-w-5xl mx-auto p-4 text-sm">
+      <p class="mb-2">© Dixon Doobies</p>
+      <p class="mb-2">Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will be fulfilled via in-store pickup or locally permitted delivery only. Content is for educational purposes only and not medical or legal advice.</p>
+      <p>Contact: <a href="mailto:info@example.com" class="underline">info@example.com</a></p>
+    </div>
+  </footer>
+  <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-gray-100 px-4 py-2 rounded hidden">Coming soon</div>
+  <div id="age-modal" class="fixed inset-0 bg-gray-900 bg-opacity-90 flex items-center justify-center hidden">
+    <div class="bg-white p-6 rounded max-w-sm mx-auto text-center">
+      <p class="mb-4 font-semibold">Are you 21 or older?</p>
+      <div class="flex justify-center gap-4">
+        <button id="age-yes" class="px-4 py-2 bg-green-800 text-white rounded">Yes</button>
+        <button id="age-no" class="px-4 py-2 bg-gray-300 rounded">No</button>
+      </div>
+      <p id="age-msg" class="mt-4 text-red-600 hidden">You must be 21+ to view this site.</p>
+    </div>
+  </div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+[build]
+  publish = "."
+  command = ""
+
+# Redirect extensionless paths to their HTML counterparts for local/Netlify parity
+[[redirects]]
+  from = "/shop"
+  to = "/shop.html"
+  status = 200
+
+[[redirects]]
+  from = "/learn"
+  to = "/learn.html"
+  status = 200
+
+[[redirects]]
+  from = "/about"
+  to = "/about.html"
+  status = 200

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dixon Doobies – Shop</title>
+  <meta name="description" content="Future online ordering for Dixon Doobies." />
+  <meta property="og:title" content="Dixon Doobies Shop" />
+  <meta property="og:description" content="Pay-ahead orders for in-store pickup and permitted delivery." />
+  <meta property="og:type" content="website" />
+  <link rel="icon" href="data:;base64,=" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/site.css" />
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div class="bg-green-900 text-gray-100 text-center text-sm p-2 sticky top-0 z-50">
+    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
+    <a href="learn.html" class="underline">Learn more</a>
+  </div>
+  <header class="bg-gray-900 text-gray-100">
+    <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
+      <a href="index.html" class="flex items-center gap-2">
+        <img src="assets/logo.svg" alt="" class="h-8 w-8" />
+        <span class="font-bold text-xl">Dixon Doobies</span>
+      </a>
+      <button id="menu-btn" class="md:hidden focus:outline-none" aria-label="Toggle navigation">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <nav id="nav" class="hidden md:flex gap-4">
+        <a href="index.html" class="hover:text-green-400">Home</a>
+        <a href="shop.html" class="hover:text-green-400">Shop</a>
+        <a href="learn.html" class="hover:text-green-400">Learn</a>
+        <a href="about.html" class="hover:text-green-400">About</a>
+      </nav>
+    </div>
+  </header>
+  <main class="min-h-screen p-6 max-w-5xl mx-auto">
+    <h1 class="text-3xl font-bold mb-4">Shop (Coming Soon)</h1>
+    <p class="mb-8">When retail opens in your area, this page will support pay-ahead orders for in-store pickup and locally permitted delivery. We do not ship.</p>
+    <div class="grid gap-4 md:grid-cols-4">
+      <div class="border p-4 text-center">
+        <h3 class="font-semibold mb-2">Flower</h3>
+        <span class="inline-block mb-2 px-2 py-1 bg-gray-200 rounded">Coming Soon</span>
+        <button class="coming-soon px-2 py-1 bg-gray-300 rounded" disabled>Add to Cart</button>
+      </div>
+      <div class="border p-4 text-center">
+        <h3 class="font-semibold mb-2">Pre-Rolls</h3>
+        <span class="inline-block mb-2 px-2 py-1 bg-gray-200 rounded">Coming Soon</span>
+        <button class="coming-soon px-2 py-1 bg-gray-300 rounded" disabled>Add to Cart</button>
+      </div>
+      <div class="border p-4 text-center">
+        <h3 class="font-semibold mb-2">Vapes</h3>
+        <span class="inline-block mb-2 px-2 py-1 bg-gray-200 rounded">Coming Soon</span>
+        <button class="coming-soon px-2 py-1 bg-gray-300 rounded" disabled>Add to Cart</button>
+      </div>
+      <div class="border p-4 text-center">
+        <h3 class="font-semibold mb-2">Edibles</h3>
+        <span class="inline-block mb-2 px-2 py-1 bg-gray-200 rounded">Coming Soon</span>
+        <button class="coming-soon px-2 py-1 bg-gray-300 rounded" disabled>Add to Cart</button>
+      </div>
+    </div>
+    <section class="mt-8 space-y-2">
+      <h2 class="text-2xl font-semibold">Future integration</h2>
+      <p>Point-of-sale hookup and METRC-synced menu.</p>
+      <p>Geo-restricted checkout for Colorado-only marketing.</p>
+    </section>
+  </main>
+  <footer class="bg-gray-900 text-gray-100 mt-8">
+    <div class="max-w-5xl mx-auto p-4 text-sm">
+      <p class="mb-2">© Dixon Doobies</p>
+      <p class="mb-2">Dixon Doobies serves adults 21+ in Colorado. We do not ship cannabis. Orders will be fulfilled via in-store pickup or locally permitted delivery only. Content is for educational purposes only and not medical or legal advice.</p>
+      <p>Contact: <a href="mailto:info@example.com" class="underline">info@example.com</a></p>
+    </div>
+  </footer>
+  <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-gray-800 text-gray-100 px-4 py-2 rounded hidden">Available at launch</div>
+  <div id="age-modal" class="fixed inset-0 bg-gray-900 bg-opacity-90 flex items-center justify-center hidden">
+    <div class="bg-white p-6 rounded max-w-sm mx-auto text-center">
+      <p class="mb-4 font-semibold">Are you 21 or older?</p>
+      <div class="flex justify-center gap-4">
+        <button id="age-yes" class="px-4 py-2 bg-green-800 text-white rounded">Yes</button>
+        <button id="age-no" class="px-4 py-2 bg-gray-300 rounded">No</button>
+      </div>
+      <p id="age-msg" class="mt-4 text-red-600 hidden">You must be 21+ to view this site.</p>
+    </div>
+  </div>
+  <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace Node/EJS project with static HTML pages and assets
- implement age-gate modal, mobile navigation, FAQ accordion, and coming-soon handlers in vanilla JS
- document local usage and deployment to Netlify or GitHub Pages
- remove binary hero image and use inline placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd8c31fac8331b85b1b594a40ee7d