### PR TITLE
style: refresh site layout with herbal background

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -2,20 +2,46 @@
 html.banner-space { scroll-behavior: smooth; }
 html.banner-space body { padding-top: 4rem; }
 body {
-  background: radial-gradient(1200px 800px at 10% -10%, var(--dd-wash) 0, #ffffff 60%);
+  background-color: #e8f5e9;
   color: var(--dd-ink);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Cpath d='M40 0c10 15 10 25 0 40C30 25 30 15 40 0z' fill='%23065f46' fill-opacity='0.05'/%3E%3Cpath d='M0 40c15-10 25-10 40 0C25 50 15 50 0 40z' fill='%23065f46' fill-opacity='0.05'/%3E%3C/svg%3E");
+  background-size: 100px 100px;
 }
 .container { max-width: 72rem; margin: 0 auto; padding: 0 1rem; }
 .section { padding: 4rem 0; }
+.section:not(.relative) {
+  background: rgba(255,255,255,0.8);
+  margin: 2rem 0;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
 .card {
   background:#fff; border-radius:1rem; box-shadow:0 10px 25px -10px rgba(0,0,0,.15); padding:1.25rem;
   transition: transform .15s ease, box-shadow .15s ease;
 }
 .card:hover { transform: translateY(-2px); box-shadow:0 20px 35px -15px rgba(0,0,0,.2); }
-.btn-primary { background: var(--dd-green); color:#fff; padding:.75rem 1rem; border-radius:.75rem; display:inline-block; }
-.btn-secondary { background:#e5e7eb; color:var(--dd-ink); padding:.75rem 1rem; border-radius:.75rem; display:inline-block; }
+.btn-primary { background: var(--dd-green); color:#fff; padding:.75rem 1rem; border-radius:.75rem; display:inline-block; text-decoration:none; }
+.btn-secondary { background:#e5e7eb; color:var(--dd-ink); padding:.75rem 1rem; border-radius:.75rem; display:inline-block; text-decoration:none; }
+.nav-link {
+  display:inline-block;
+  padding:0.5rem 0.75rem;
+  border-radius:0.5rem;
+  background:rgba(6,95,70,0.1);
+  color:var(--dd-ink);
+  text-decoration:none;
+}
+.nav-link:hover { background:rgba(6,95,70,0.2); }
 .nav-panel { overflow:hidden; max-height:0; transition:max-height .25s ease; background:#fff; border-top:1px solid #e5e7eb; }
-.nav-panel a { display:block; padding:1rem; border-bottom:1px solid #eee; }
+.nav-panel a { display:block; padding:1rem; border-bottom:1px solid #eee; text-decoration:none; }
+.note-link {
+  display:inline-block;
+  padding:0.25rem 0.5rem;
+  border-radius:0.25rem;
+  background:rgba(255,255,255,0.15);
+  color:#fff;
+  text-decoration:none;
+}
+.note-link:hover { background:rgba(255,255,255,0.25); }
 .toast { position: fixed; bottom: 1rem; right: 1rem; background: var(--dd-green); color:#f9fafb; padding: 0.5rem 1rem; border-radius: 0.5rem; }
 @media (prefers-reduced-motion: reduce) {
   .nav-panel, .card { transition: none; }

--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
 <body>
   <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
     21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="underline">Learn more</a>
+    <a href="/knowledge.html" class="note-link">Learn more</a>
   </div>
 
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-4">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-8 w-auto"></a>
+    <div class="container flex items-center justify-between py-2">
+      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
       <nav class="hidden md:flex space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
@@ -59,7 +59,7 @@
       <h2 class="text-3xl font-semibold mb-4">[ABOUT_BLURB]</h2>
     </section>
 
-    <section class="section bg-[var(--dd-wash)]">
+    <section class="section">
       <div class="container grid gap-8 md:grid-cols-3">
         <div class="card text-center">
           <div class="mb-4"><div class="mx-auto w-12 h-12 bg-gray-200 rounded-full"></div></div>
@@ -90,7 +90,7 @@
       <p class="text-sm mt-4">*Delivery where permitted in Colorado.</p>
     </section>
 
-    <section id="newsletter" class="section bg-[var(--dd-wash)]">
+    <section id="newsletter" class="section">
       <div class="container text-center">
         <h2 class="text-3xl font-semibold mb-4">Join our newsletter</h2>
         <form id="newsletter-form" class="max-w-xl mx-auto flex flex-col sm:flex-row gap-4">

--- a/knowledge.html
+++ b/knowledge.html
@@ -12,12 +12,12 @@
 <body>
   <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
     21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="underline">Learn more</a>
+    <a href="/knowledge.html" class="note-link">Learn more</a>
   </div>
 
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-4">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-8 w-auto"></a>
+    <div class="container flex items-center justify-between py-2">
+      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
       <nav class="hidden md:flex space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
@@ -44,7 +44,7 @@
       <p class="text-xl mb-8">[KNOWLEDGE_INTRO]</p>
     </section>
 
-    <section class="section bg-[var(--dd-wash)]">
+    <section class="section">
       <div class="container space-y-12">
         <div>
           <h2 class="text-2xl font-semibold mb-2">101</h2>
@@ -98,7 +98,7 @@
       </div>
     </section>
 
-    <section id="newsletter" class="section bg-[var(--dd-wash)]">
+    <section id="newsletter" class="section">
       <div class="container text-center">
         <h2 class="text-3xl font-semibold mb-4">Join our newsletter</h2>
         <form id="newsletter-form" class="max-w-xl mx-auto flex flex-col sm:flex-row gap-4">

--- a/product.html
+++ b/product.html
@@ -12,12 +12,12 @@
 <body>
   <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
     21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="underline">Learn more</a>
+    <a href="/knowledge.html" class="note-link">Learn more</a>
   </div>
 
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-4">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-8 w-auto"></a>
+    <div class="container flex items-center justify-between py-2">
+      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
       <nav class="hidden md:flex space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
@@ -44,7 +44,7 @@
       <p class="text-xl mb-8">[PRODUCTS_INTRO]</p>
     </section>
 
-    <section class="section bg-[var(--dd-wash)]">
+    <section class="section">
       <div class="container grid gap-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         <div class="card flex flex-col">
           <img src="https://via.placeholder.com/400x300.png?text=Product+1" alt="" class="rounded mb-4">


### PR DESCRIPTION
## Summary
- introduce soft herbal green background with subtle leaf pattern
- make header and navigation links compact boxed buttons
- add white card styling to content sections for clearer separation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac9245c2f48331a9fb0c0595a9a5b8