### PR TITLE
Streamlined header and refreshed background

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,11 +1,10 @@
 :root { --dd-green: #065f46; --dd-ink: #111827; --dd-wash: #f5faf7; }
-html.banner-space { scroll-behavior: smooth; }
-html.banner-space body { padding-top: 4rem; }
+html { scroll-behavior: smooth; }
 body {
-  background-color: #e8f5e9;
+  background-color: #d0e8d0;
   color: var(--dd-ink);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Cpath d='M40 0c10 15 10 25 0 40C30 25 30 15 40 0z' fill='%23065f46' fill-opacity='0.05'/%3E%3Cpath d='M0 40c15-10 25-10 40 0C25 50 15 50 0 40z' fill='%23065f46' fill-opacity='0.05'/%3E%3C/svg%3E");
-  background-size: 100px 100px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='50' height='50' viewBox='0 0 50 50'%3E%3Cpath d='M25 0 L30 10 L40 6 L34 18 L44 22 L34 26 L40 38 L30 34 L25 44 L20 34 L10 38 L16 26 L6 22 L16 18 L10 6 L20 10 Z' fill='%23054e3a' fill-opacity='0.08'/%3E%3C/svg%3E");
+  background-size: 80px 80px;
 }
 .container { max-width: 72rem; margin: 0 auto; padding: 0 1rem; }
 .section { padding: 4rem 0; }
@@ -31,18 +30,8 @@ body {
   text-decoration:none;
 }
 .nav-link:hover { background:rgba(6,95,70,0.2); }
-.nav-panel { overflow:hidden; max-height:0; transition:max-height .25s ease; background:#fff; border-top:1px solid #e5e7eb; }
-.nav-panel a { display:block; padding:1rem; border-bottom:1px solid #eee; text-decoration:none; }
-.note-link {
-  display:inline-block;
-  padding:0.25rem 0.5rem;
-  border-radius:0.25rem;
-  background:rgba(255,255,255,0.15);
-  color:#fff;
-  text-decoration:none;
-}
-.note-link:hover { background:rgba(255,255,255,0.25); }
+/* Removed mobile nav panel and note banner styles */
 .toast { position: fixed; bottom: 1rem; right: 1rem; background: var(--dd-green); color:#f9fafb; padding: 0.5rem 1rem; border-radius: 0.5rem; }
 @media (prefers-reduced-motion: reduce) {
-  .nav-panel, .card { transition: none; }
+  .card { transition: none; }
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="banner-space">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,31 +10,14 @@
   <link href="/css/site.css" rel="stylesheet">
 </head>
 <body>
-  <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
-    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="note-link">Learn more</a>
-  </div>
-
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-2">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
-      <nav class="hidden md:flex space-x-8" aria-label="Primary">
+    <div class="container flex flex-col items-center py-1">
+      <a href="/index.html" class="mb-1"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
+      <nav class="flex justify-center space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
         <a href="/knowledge.html" class="nav-link">Learn</a>
       </nav>
-      <a href="#newsletter" class="btn-primary hidden md:inline-block">Join Newsletter</a>
-      <button id="nav-toggle" class="md:hidden p-2" aria-label="Toggle navigation">
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800"></span>
-      </button>
-    </div>
-    <div id="nav-panel" class="nav-panel md:hidden">
-      <a href="/index.html">Home</a>
-      <a href="/product.html">Products</a>
-      <a href="/knowledge.html">Learn</a>
-      <a href="#newsletter">Join Newsletter</a>
     </div>
   </header>
 

--- a/knowledge.html
+++ b/knowledge.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="banner-space">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,31 +10,14 @@
   <link href="/css/site.css" rel="stylesheet">
 </head>
 <body>
-  <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
-    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="note-link">Learn more</a>
-  </div>
-
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-2">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
-      <nav class="hidden md:flex space-x-8" aria-label="Primary">
+    <div class="container flex flex-col items-center py-1">
+      <a href="/index.html" class="mb-1"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
+      <nav class="flex justify-center space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
         <a href="/knowledge.html" class="nav-link">Learn</a>
       </nav>
-      <a href="#newsletter" class="btn-primary hidden md:inline-block">Join Newsletter</a>
-      <button id="nav-toggle" class="md:hidden p-2" aria-label="Toggle navigation">
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800"></span>
-      </button>
-    </div>
-    <div id="nav-panel" class="nav-panel md:hidden">
-      <a href="/index.html">Home</a>
-      <a href="/product.html">Products</a>
-      <a href="/knowledge.html">Learn</a>
-      <a href="#newsletter">Join Newsletter</a>
     </div>
   </header>
 

--- a/product.html
+++ b/product.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="banner-space">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,31 +10,14 @@
   <link href="/css/site.css" rel="stylesheet">
 </head>
 <body>
-  <div class="fixed top-0 inset-x-0 z-50 bg-green-900 text-white text-center text-xs py-2" role="note">
-    21+ only. No shipping. Orders are for in-store pickup or permitted delivery within Colorado municipalities that allow it.
-    <a href="/knowledge.html" class="note-link">Learn more</a>
-  </div>
-
   <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-    <div class="container flex items-center justify-between py-2">
-      <a href="/index.html" class="flex items-center"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
-      <nav class="hidden md:flex space-x-8" aria-label="Primary">
+    <div class="container flex flex-col items-center py-1">
+      <a href="/index.html" class="mb-1"><img src="/assets/logo.svg" alt="Dixon Doobies" class="h-6 w-auto"></a>
+      <nav class="flex justify-center space-x-8" aria-label="Primary">
         <a href="/index.html" class="nav-link">Home</a>
         <a href="/product.html" class="nav-link">Products</a>
         <a href="/knowledge.html" class="nav-link">Learn</a>
       </nav>
-      <a href="#newsletter" class="btn-primary hidden md:inline-block">Join Newsletter</a>
-      <button id="nav-toggle" class="md:hidden p-2" aria-label="Toggle navigation">
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800 mb-1"></span>
-        <span class="block w-6 h-0.5 bg-gray-800"></span>
-      </button>
-    </div>
-    <div id="nav-panel" class="nav-panel md:hidden">
-      <a href="/index.html">Home</a>
-      <a href="/product.html">Products</a>
-      <a href="/knowledge.html">Learn</a>
-      <a href="#newsletter">Join Newsletter</a>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Shrink header and center navigation beneath the logo on every page
- Remove 21+ notice banner and mobile nav panel
- Introduce darker green leaf-pattern background for the site

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac98d268e08331b81cd6d16e37d0f5